### PR TITLE
Handle nested lists in case conversions

### DIFF
--- a/cure/__init__.py
+++ b/cure/__init__.py
@@ -7,8 +7,8 @@ from enum import IntEnum
 from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Tuple, Union, cast
 
-from .builder import Builder
 from .__version_data__ import __version__, __version_info__  # noqa
+from .builder import Builder
 
 __author__ = "Carl Oscar Aaro"
 __email__ = "hello@carloscar.com"

--- a/cure/__init__.py
+++ b/cure/__init__.py
@@ -157,6 +157,38 @@ def trail_name(kw: str) -> str:
     return kw
 
 
+def case_shift_dict_or_list(
+    value: Union[Dict, List], case_shift_fn: Callable, recursive: bool = True
+) -> Union[Dict, List]:
+    if isinstance(value, Dict):
+        if recursive:
+            return {
+                case_shift_fn(k): case_shift_dict_or_list(v, case_shift_fn, recursive)
+                if isinstance(v, (Dict, List))
+                else v
+                for k, v in value.items()
+            }
+        return {case_shift_fn(k): v for k, v in value.items()}
+
+    if isinstance(value, List):
+        if recursive:
+            return [
+                case_shift_dict_or_list(entry, case_shift_fn, recursive) if isinstance(entry, (Dict, List)) else entry
+                for entry in value
+            ]
+        else:
+            return value
+
+    raise TypeError(f"Got unexpected type: {type(value)}")
+
+
+def snake_case_dict(d: Dict, recursive: bool = True) -> Dict:
+    if not isinstance(d, Dict):
+        raise TypeError(f"Got unexpected type: {type(d)}")
+
+    return cast(Dict, case_shift_dict_or_list(d, snake_case_name, recursive))
+
+
 def snake_case_name(kw: str) -> str:
     result = ""
 
@@ -171,18 +203,11 @@ def snake_case_name(kw: str) -> str:
     return result
 
 
-def snake_case_dict(d: Dict, recursive: bool = True) -> Dict:
-    result = {}
+def camel_case_dict(d: Dict, recursive: bool = True) -> Dict:
+    if not isinstance(d, Dict):
+        raise TypeError(f"Got unexpected type: {type(d)}")
 
-    for k, v in d.items():
-        if recursive and isinstance(v, Dict):
-            v = snake_case_dict(v, recursive)
-        if recursive and isinstance(v, List):
-            v = [snake_case_dict(x, recursive) for x in v]
-
-        result[snake_case_name(k)] = v
-
-    return result
+    return cast(Dict, case_shift_dict_or_list(d, camel_case_name, recursive))
 
 
 def camel_case_name(kw: str) -> str:
@@ -198,20 +223,6 @@ def camel_case_name(kw: str) -> str:
             next_upper = False
         else:
             result += c
-
-    return result
-
-
-def camel_case_dict(d: Dict, recursive: bool = True) -> Dict:
-    result = {}
-
-    for k, v in d.items():
-        if recursive and isinstance(v, Dict):
-            v = camel_case_dict(v, recursive)
-        if recursive and isinstance(v, List):
-            v = [camel_case_dict(x, recursive) for x in v]
-
-        result[camel_case_name(k)] = v
 
     return result
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,7 @@
 import pytest
 
 import cure
-from cure import decorator
+from cure import camel_case_dict, case_shift_dict_or_list, decorator, snake_case_dict
 
 
 @pytest.mark.parametrize("value", [cure(), decorator(), cure.decorator()])
@@ -54,3 +54,21 @@ def test_invalid_argument(value):
     x = X()
     with pytest.raises(TypeError):
         value(x)
+
+
+@pytest.mark.parametrize("value", [None, "a string", 1337, 133.7, True])
+def test_case_shift_dict_or_list_invalid_type(value):
+    with pytest.raises(TypeError):
+        case_shift_dict_or_list(value, lambda: True)
+
+
+@pytest.mark.parametrize("value", [None, "a string", 1337, 133.7, True])
+def test_snake_case_dict_invalid_type(value):
+    with pytest.raises(TypeError):
+        snake_case_dict(value)
+
+
+@pytest.mark.parametrize("value", [None, "a string", 1337, 133.7, True])
+def test_camel_case_dict_invalid_type(value):
+    with pytest.raises(TypeError):
+        camel_case_dict(value)

--- a/tests/test_snake_case.py
+++ b/tests/test_snake_case.py
@@ -7,7 +7,9 @@ from cure import (
     KEYWORD_SNAKE_CASE,
     KEYWORD_SNAKE_CASE_RECURSIVE,
     KEYWORD_TRAILING_UNDERSCORES,
+    case_shift_dict_or_list,
     cure,
+    snake_case_name,
 )
 
 
@@ -222,3 +224,24 @@ def test_snake_case(options, kwargs, expected):
     else:
         decorator = cure(options)
     assert decorator(values)(**kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "case_shift_fn, value, expected, recursive",
+    [
+        (
+            snake_case_name,
+            [{"someKey": "somevalue"}, "just a string", 123],
+            [{"some_key": "somevalue"}, "just a string", 123],
+            True,
+        ),
+        (
+            snake_case_name,
+            [{"someKey": "somevalue"}, "just a string", 123],
+            [{"someKey": "somevalue"}, "just a string", 123],
+            False,
+        ),
+    ],
+)
+def test_case_shift_dict_or_list(case_shift_fn, value, expected, recursive):
+    assert case_shift_dict_or_list(value, case_shift_fn, recursive) == expected

--- a/tests/test_snake_case.py
+++ b/tests/test_snake_case.py
@@ -99,6 +99,36 @@ def values(**kwargs):
             },
         ),
         (
+            KEYWORD_SNAKE_CASE_RECURSIVE,
+            {
+                "resources": [
+                    {"resourceId": "1", "data": ["ABC"], "other-value": True},
+                    {"resourceId": "2", "data": ["DEF"], "other-value": True},
+                ]
+            },
+            {
+                "resources": [
+                    {"resource_id": "1", "data": ["ABC"], "other_value": True},
+                    {"resource_id": "2", "data": ["DEF"], "other_value": True},
+                ]
+            },
+        ),
+        (
+            KEYWORD_SNAKE_CASE_RECURSIVE,
+            {
+                "resources": [
+                    {"resourceId": "1", "data": [["ABC"]], "other-value": True},
+                    {"resourceId": "2", "data": [[{"coolBeans": "ABC"}]], "other-value": True},
+                ]
+            },
+            {
+                "resources": [
+                    {"resource_id": "1", "data": [["ABC"]], "other_value": True},
+                    {"resource_id": "2", "data": [[{"cool_beans": "ABC"}]], "other_value": True},
+                ]
+            },
+        ),
+        (
             KEYWORD_SNAKE_CASE,
             {
                 "resources": [
@@ -151,6 +181,36 @@ def values(**kwargs):
                 "resources": [
                     {"resourceId": "1", "data": "ABC", "otherValue": True},
                     {"resourceId": "2", "data": "DEF", "otherValue": True},
+                ]
+            },
+        ),
+        (
+            KEYWORD_CAMEL_CASE_RECURSIVE,
+            {
+                "resources": [
+                    {"resource_id": "1", "data": ["ABC"], "other-value": True},
+                    {"resource_id": "2", "data": ["DEF"], "other-value": True},
+                ]
+            },
+            {
+                "resources": [
+                    {"resourceId": "1", "data": ["ABC"], "otherValue": True},
+                    {"resourceId": "2", "data": ["DEF"], "otherValue": True},
+                ]
+            },
+        ),
+        (
+            KEYWORD_CAMEL_CASE_RECURSIVE,
+            {
+                "resources": [
+                    {"resource_id": "1", "data": [["ABC"]], "other-value": True},
+                    {"resource_id": "2", "data": [[{"cool_beans": "ABC"}]], "other-value": True},
+                ]
+            },
+            {
+                "resources": [
+                    {"resourceId": "1", "data": [["ABC"]], "otherValue": True},
+                    {"resourceId": "2", "data": [[{"coolBeans": "ABC"}]], "otherValue": True},
                 ]
             },
         ),


### PR DESCRIPTION
This fixes a bug where elements in lists were always treated as dictionaries during the case conversion. It preserves the original interface with optional recursion and functions that are type aware. 

 